### PR TITLE
parse v1.19.1 (ursaverance effort)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "parse" %}
-{% set version = "1.19.0" %}
-{% set sha256 = "9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b" %}
+{% set version = "1.19.1" %}
 
 package:
   name: {{ name|lower }}
@@ -9,25 +8,29 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: cc3a47236ff05da377617ddefa867b7ba983819c664e1afe46249e5b469be464
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
     - pip
     - python
     - setuptools
-
+    - wheel
   run:
     - python
 
 test:
   imports:
     - parse
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/r1chardj0n3s/parse


### PR DESCRIPTION
[PKG-2695] parse v1.19.1

dev_url: https://github.com/r1chardj0n3s/parse 
conda-forge: https://github.com/conda-forge/parse-feedstock
dependencies: https://github.com/r1chardj0n3s/parse/blob/1.19.1/pyproject.toml

- linter
- update to version `1.19.1`, update sha
- remove `noarch`


**Dependency for:**
- AnacondaRecipes/parse_type-feedstock#2
- AnacondaRecipes/behave-feedstock#2

[PKG-2695]: https://anaconda.atlassian.net/browse/PKG-2695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
